### PR TITLE
Codev: Fix for issue #1 - UsernameValidator allows trailing newline in usernames Description

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -1,3 +1,9 @@
+# django/django/contrib/auth/validators.py
+
+
+
+
+
 import re
 
 from django.core import validators
@@ -7,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 
 @deconstructible
 class ASCIIUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'\A[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only English letters, '
         'numbers, and @/./+/-/_ characters.'
@@ -17,7 +23,7 @@ class ASCIIUsernameValidator(validators.RegexValidator):
 
 @deconstructible
 class UnicodeUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'\A[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only letters, '
         'numbers, and @/./+/-/_ characters.'


### PR DESCRIPTION
This PR was created automatically by Codev to address issue #1.

## Issue
UsernameValidator allows trailing newline in usernames Description

ASCIIUsernameValidator and UnicodeUsernameValidator use the regex
r'^[\w.@+-]+$'
The intent is to only allow alphanumeric characters as well as ., @, +, and -. However, a little known quirk of Python regexes is that $ will also match a trailing newline. Therefore, the user name validators will accept usernames which end with a newline. You can avoid this behavior by instead using \A and \Z to terminate regexes. For example, the validator regex could be changed to
r'\A[\w.@+-]+\Z'
in order to reject usernames that end with a newline.
I am not sure how to officially post a patch, but the required change is trivial - using the regex above in the two validators in contrib.auth.validators.
## Codev

### 📝 Plan

> The solution is straightforward: replace the current regex anchors `^` and `$` with `\A` and `\Z` respectively in both validator classes. These alternative anchors are more strict: `\A` matches only at the start of the string (like `^`), and `\Z` matches only at the end of the string, and NOT before a trailing newline (unlike `$`). This change will ensure that usernames with trailing newlines are properly rejected by the validators.

---

### 🗂️ Files Modified

| File Path | Key Blocks Edited |
|-----------|-------------------|
| `django/django/contrib/auth/validators:module` | `django/django/contrib/auth/validators:module` |

---

### 🏆 Solution Candidates

| Candidate | Score | File Score | Winner |
|-----------|-------|------------|--------|
| 1 | 10 | 7.45 | ✅ |

---

### 🧩 Patch Details


<summary>Show Patch Diff</summary>

```diff
diff --git a/django/contrib/auth/validators.py b/django/contrib/auth/validators.py
index b4878cfd45..3e83a81ff9 100644
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -1,3 +1,9 @@
+# django/django/contrib/auth/validators.py
+
+
+
+
+
 import re
 
 from django.core import validators
@@ -7,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 
 @deconstructible
 class ASCIIUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'\A[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only English letters, '
         'numbers, and @/./+/-/_ characters.'
@@ -17,7 +23,7 @@ class ASCIIUsernameValidator(validators.RegexValidator):
 
 @deconstructible
 class UnicodeUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'\A[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only letters, '
         'numbers, and @/./+/-/_ characters.'
```

---

### 📊 Solution Metrics

| Metric | Value |
|--------|-------|
| Total Solution Candidates | 1 |
| Iterations in Dev Round | 2 |
| Success Count | 1 |
| Partial Count | 0 |
| Evaluator Count | 1 |
| Score | 8.397 |

#### Score Details

| Metric | Value | Weight | Score |
|--------|-------|--------|-------|
| SUCCESS | 1 | 3 | 3.0 |
| PASS | 1 | 3 | 3 |
| Size | 3.0 | -0.001 | -0.003 |
| Code Iter | 1 | -0.1 | 0.4 |
| HighestEvidenceRank | 1 | -1 | 1 |
| HighestEvidenceConfidence | 95.0 | 0.1 | 1.0 |

---
